### PR TITLE
fix https://github.com/ildarkhasanshin/cuda_folding_caption/issues/18

### DIFF
--- a/install.inf
+++ b/install.inf
@@ -7,7 +7,7 @@ homepage=https://github.com/ildarkhasanshin/cuda_folding_caption/
 
 [item1]
 section=events
-events=on_caret_slow,on_focus
+events=on_caret_slow,on_focus,on_close
 
 [item2]
 section=commands


### PR DESCRIPTION
- combined `self.indexes` and `self.h_pfs` lists into one dict `self.indexes` ("key" will hold PROP_HANDLE_PARENT, "value" will hold statusbar handle). After this it is easy to fix issue #18 by just adding one line to on_close event:

```python
self.indexes.pop(ed_self.get_prop(PROP_HANDLE_PARENT), None)
```

- also all statusbars were updated on caret change, not just visible one. FIXED.